### PR TITLE
Fix check_run webhook logic error

### DIFF
--- a/nixpkgs_merge_bot/webhook/check_run.py
+++ b/nixpkgs_merge_bot/webhook/check_run.py
@@ -47,12 +47,12 @@ def check_run_response(action: str) -> HttpResponse:
 def check_run(body: dict[str, Any], settings: Settings) -> HttpResponse:
     check_run = CheckRun.from_json(body)
     log.debug(
-        f"Check Run {check_run.name} with commit id {check_run.head_sha} is in state: {check_run.status}"
+        f"Check Run {check_run.name} with commit id {check_run.head_sha} is in state: {check_run.status} and conclusion: {check_run.conclusion}"
     )
-    if check_run.conclusion == "completed":
+    if check_run.status == "completed":
         db = Database(settings)
         log.debug(
-            f"Check Run {check_run.name} with commit id {check_run.head_sha} is in state: {check_run.status}"
+            f"Check Run {check_run.name} with commit id {check_run.head_sha} completed"
         )
         values = db.get(check_run.head_sha)
         for value in values:

--- a/nixpkgs_merge_bot/webhook/handler.py
+++ b/nixpkgs_merge_bot/webhook/handler.py
@@ -5,7 +5,7 @@ from http.server import BaseHTTPRequestHandler
 
 from ..settings import Settings
 from . import http_header
-from .check_suite import check_run
+from .check_run import check_run
 from .errors import HttpError
 from .issue_comment import issue_comment, review_comment
 from .secret import WebhookSecret


### PR DESCRIPTION
We incorrectly used the conclusion of the check_run instead of the status attribute to see if a check run was completed