### PR TITLE
remove CI result validation note from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@ limitations:
 - Supports merging only into the `master`, `staging`, and `staging-next`
   branches.
 
-- CI results validation is currently absent.
-
 ---
 
 <img src="https://qr.helsinki-systems.de/logo/github" height="200">


### PR DESCRIPTION
No longer valid, I learnt this the hard way D: