### PR TITLE
Merge via GraphQL's enablePullRequestAutoMerge

### DIFF
--- a/nixpkgs_merge_bot/commands/merge.py
+++ b/nixpkgs_merge_bot/commands/merge.py
@@ -143,18 +143,13 @@ def merge_command(issue_comment: IssueComment, settings: Settings) -> HttpRespon
             return issue_response("merge-postponed")
         if check_suite_result.success:
             try:
-                commenter_info = client.get_user_info(
-                    issue_comment.commenter_login
-                ).json()
                 log.info(
                     f"{issue_comment.issue_number}: Trying to merge pull request, with head_sha: {pull_request.head_sha}"
                 )
                 client.merge_pull_request(
-                    issue_comment.repo_owner,
-                    issue_comment.repo_name,
                     issue_comment.issue_number,
+                    pull_request.node_id,
                     pull_request.head_sha,
-                    commenter_info,
                 )
                 merge_tracker_link = (
                     "Merge completed (#306934)"  # Link Issue to track merges

--- a/nixpkgs_merge_bot/github/pull_request.py
+++ b/nixpkgs_merge_bot/github/pull_request.py
@@ -13,6 +13,7 @@ class PullRequest:
     repo_owner: str
     repo_name: str
     number: int
+    node_id: str
     title: str
     state: str
     head_sha: str
@@ -28,6 +29,7 @@ class PullRequest:
                 repo_owner=body["base"]["repo"]["owner"]["login"],
                 repo_name=body["base"]["repo"]["name"],
                 number=body["number"],
+                node_id=body["node_id"],
                 title=body["title"],
                 state=body["state"],
                 head_sha=body["head"]["sha"],


### PR DESCRIPTION
This changes the merge method to support Merge Queues.

I tested the GraphQL request, but not any of the python code. How do I do that?

Resolves #202 

Will probably resolve #179 as well, because auto-merge will just wait for the next merge commit to be calculated instead of failing.

cc @NixOS/nixpkgs-ci 