### PR TITLE
readme: document our policy for approving changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ requests on nixpkgs, we're enhancing the merging process with this bot! 🎉
 
 [Mergebot RFC](https://github.com/NixOS/rfcs/pull/172)
 
+See also [approving changes](#approving-changes) below, for how the mergebot can
+evolve beyond the RFC.
+
 ## Features
 
 This bot empowers package maintainers by granting them the capability to merge
@@ -42,6 +45,24 @@ limitations:
 
 - Supports merging only into the `master`, `staging`, and `staging-next`
   branches.
+
+## Approving changes
+
+As with any project, fixes, improvements, and other changes are expected.
+
+Usually, such changes can be approved internally by the @NixOS/nixpkgs-ci team
+and other repository collaborators. However, changes that increase the scope of
+**what** the mergebot will merge or **who** can trigger merging will typically
+require additional acknowledgement from a "higher power".
+
+Such "higher powers" include anyone responsible for deciding who can merge
+things into nixpkgs, principally:
+
+- The @NixOS/commit-bit-delegation
+- The @NixOS/steering committee
+
+A ping for approval not responded to within a week will usually be interpreted
+as a silent acknowledgement.
 
 ---
 


### PR DESCRIPTION
As discussed in today's meeting, we should document which changes can be approved internally and which require some form of acknowledgement from an authority figure.

The authority on who can merge into nixpkgs is principally the @NixOS/commit-bit-delegation, with the ultimate power coming from the @NixOS/steering committee. If other authorities are introduced, such as a nixpkgs-core team, they can be added to this list; although the wording is intentionally vague so that all authorities do not need to be explicitly listed.

As discussed in the meeting, most changes will not increase scope and therefore do not require external acknowledgement. Even changes that do increase scope will usually only require making the authorities _aware_ of the change and giving them an opportunity to have input or veto. For documentation purposes, I've phrased this as:

> A ping for approval not responded to within a week will usually be interpreted as a silent acknowledgement.

Suggestions for improving the wording, grammar, semantics, and/or actual policy are welcome. As are follow-up PRs, if you can see ways to improve this after it's been merged. I've intentionally phrased the PR description differently to the actual README, so that the intention behind the change is hopefully clearer and it'll be easier to suggest improvements.

For posterity, the original wording drafted during the meeting was:

<details><summary>Original wording draft</summary>
<p>

> #### Increases in scope for (e.g.) merge strategies
>
> - Increasing the scope of what can be merged or by whom must be approved by a "higher entity" such as:
>   - The commit-bit-delegation team
>   - The Steering Committee
>   Note: being pinged and not responding within a week is considered a silent acknowledgment
>
> - Other changes that do not increase who can merge things into nixpkgs can be approved internally between the nixpkgs-ci team and repo collaborators.

</p>
</details> 

cc @Lassulus @Scriptkiddi @DominicWrege @NixOS/nixpkgs-ci
