### PR TITLE
readme: update matrix channel link

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ through a comment detailing the discrepancies.
 
 ## Contact
 
-We have a [matrix channel](https://matrix.to/#/#nixpkgs-merge-bot:lassul.us).
+We can be found on the
+[nixpkgs-ci matrix channel](https://matrix.to/#/#nixpkgs-ci:nixos.org).
 
 ## Constraints
 


### PR DESCRIPTION
The matrix channel was renamed by @Lassulus today, from `nixpkgs-merge-bot` to `nixpkgs-ci` and moved to `nixos.org`, in an effort to broaden its scope and introduce an official place for more general nixpkgs CI discussions to take place.

This PR updates the contact wording and invite link.
