### PR TITLE
readme: list nixpkgs-core as a nixpkgs authority

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ things into nixpkgs, principally:
   [@NixOS/commit-bit-delegation](https://github.com/orgs/NixOS/teams/commit-bit-delegation)
 - The [@NixOS/nixpkgs-core](https://github.com/orgs/NixOS/teams/nixpkgs-core)
   team
-- The [@NixOS/steering](https://github.com/orgs/NixOS/teams/steering) committee
 
 A ping for approval not responded to within a week will usually be interpreted
 as a silent acknowledgement.


### PR DESCRIPTION
- **readme: fix links to authoritative teams**

I noticed that the team references added in #227 don't actually link to the teams in question.

- **readme: list nixpkgs-core as a nixpkgs authority**

Explicitly mention the [new](https://github.com/NixOS/nixpkgs/issues/445849) @NixOS/nixpkgs-core team in our list of authorities on who can merge into nixpkgs.


Aside: yes the formatting is a bit cursed, but it is enforced by our current treefmt config. Maybe we just need to `exclude *.md` from whichever formatter is responsible?